### PR TITLE
Focus the cursor in the autocomplete input when the page loads

### DIFF
--- a/src/js/autocomplete.js
+++ b/src/js/autocomplete.js
@@ -31,6 +31,7 @@
     opts.label = _.create('label', '', opts.form);
     opts.label.innerHTML = 'Search:';
     opts.input = _.create('input', 'autocomplete-input', opts.form);
+    opts.input.focus();
     opts.output = _.create('ul', 'autocomplete-results', opts.container);
   }
 


### PR DESCRIPTION
Uses `.focus()` to focus on the input as soon as it is created.