### PR TITLE
If 'detail' param is set to true, display the detail panel on load

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -45,6 +45,8 @@
       output: document.querySelector('.autocomplete-detail')
     });
 
+    if (params.detail === 'true') detail.show();
+
     toolbar.init();
   }
 


### PR DESCRIPTION
If 'detail' param is set to true, display the detail panel on load.

`https://fws.gov/southeast/mega-map?detail=true`

Addressed #6 