### PR TITLE
Autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "async": "^2.0.1",
     "classlist-polyfill": "^1.0.2",
     "events": "^1.1.0",
+    "has-class": "^1.0.6",
     "leaflet": "^1.0.0-beta.2",
     "leaflet-knn": "^0.1.0",
     "leaflet-providers": "^1.1.14",
@@ -86,11 +87,13 @@
     "lodash.defaults": "^3.1.2",
     "lodash.filter": "^4.5.1",
     "lodash.find": "^3.2.1",
+    "lodash.foreach": "^4.4.1",
     "lodash.includes": "^4.2.0",
     "lodash.map": "^4.5.1",
     "lunr": "^0.6.0",
     "madison": "^1.0.1",
     "query-string": "^4.2.2",
+    "tabbable": "^1.0.4",
     "underscore.string": "^3.2.2",
     "xhr": "^2.2.0"
   }

--- a/src/js/autocomplete.js
+++ b/src/js/autocomplete.js
@@ -38,6 +38,7 @@
     opts.form.addEventListener('submit', function (e) { e.preventDefault(); });
     opts.input.addEventListener('keyup', inputKeyup);
     opts.input.addEventListener('focus', focusInput);
+    opts.container.addEventListener('keyup', navigationHandler);
     emitter.on('marker:click', updateInputValue);
     emitter.on('blur:input', blurInput);
     opts.input.focus();
@@ -74,7 +75,7 @@
     }
   }
 
-  function inputKeyup() {
+  function inputKeyup(e) {
     emitter.emit('autocomplete:keyup');
     if (opts.input.value.length === 0) {
       emitter.emit('autocomplete:empty', opts.data);
@@ -82,6 +83,43 @@
       return;
     } else if (opts.input.value.length < opts.minLength) return;
     search(opts.input.value);
+  }
+
+  function navigationHandler(e) {
+    // Up Key should go to the previous result in the list
+    if (e.which === 38) goToTabbableElement('previous');
+    // Down Key should go to the next result in the list
+    if (e.which === 40) goToTabbableElement('next');
+    // Escape should clear the results and focus on the input
+    if (e.which === 27) {
+      opts.input.focus();
+      opts.output.innerHTML = '';
+    }
+  }
+
+  function goToTabbableElement(direction) {
+    if ( !_.hasClass(opts.container, 'active') ) return;
+    var index, modifier;
+    var tabbable = _.tabbable(opts.container);
+    if (direction === 'next') modifier = 1;
+    else if (direction === 'previous') modifier = -1;
+    else throw new Error('Direction for _goToTabbableElement must be \'next\' or \'last\'.');
+
+    _.each(tabbable, function (el, i) {
+      if ( document.activeElement === el ) index = i + modifier;
+    });
+
+    if (index === -1) index = 0; // Don't go further than the first element
+    else if (index === tabbable.length) index = index -1; // Don't go further than the last element
+    tabbable[index].focus();
+  }
+
+  function focusResults() {
+    var active = document.activeElement;
+    var tabbable = _.tabbable(opts.container);
+    console.log(tabbable);
+    if ( _.hasClass(active, 'autocomplete-input') ) opts.output.querySelector('a').focus();
+
   }
 
   function createIndex () {

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -9,13 +9,16 @@
     map: require('lodash.map'),
     filter: require('lodash.filter'),
     includes: require('lodash.includes'),
+    each: require('lodash.foreach'),
     slugify: require('underscore.string/slugify'),
     create: create,
     remove: remove,
     addClass: addClass,
     addClasses: addClasses,
+    hasClass: require('has-class'),
     removeClass: removeClass,
-    toggleClass: toggleClass
+    toggleClass: toggleClass,
+    tabbable: require('tabbable')
   };
 
   function create(tagName, className, container) {

--- a/src/templates/autocomplete.jade
+++ b/src/templates/autocomplete.jade
@@ -2,5 +2,5 @@
 each office in offices
   - var slug = "?q=" + _.slugify(office.name).toLowerCase();
   li
-    a(href=slug)
+    a(href=slug, class="autocomplete-link")
       = office.name


### PR DESCRIPTION
Autocomplete widget now supports basic keyboard input.  Up key moves to previous result link or into the autocomplete input if you're currently in the top most result.  Down key moves to next result.  Escape key clears the results list and focuses on the autocomplete input.